### PR TITLE
Vertical Scrool bug fixed.

### DIFF
--- a/src/SilverlightApp/Views/Participantes.xaml
+++ b/src/SilverlightApp/Views/Participantes.xaml
@@ -31,7 +31,7 @@
                  Grid.RowSpan="2"
                  Margin="20,5" 
                  FontSize="12"
-                 
+                 SizeChanged="ParticipantsList_SizeChanged"
                  >
             <ListBox.ItemTemplate>
                 <DataTemplate>
@@ -49,7 +49,7 @@
             </ListBox.ItemTemplate>
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <toolkit:WrapPanel Orientation="Vertical" MaxHeight="400"/>
+                    <toolkit:WrapPanel Orientation="Vertical"/>
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
         </ListBox>

--- a/src/SilverlightApp/Views/Participantes.xaml.cs
+++ b/src/SilverlightApp/Views/Participantes.xaml.cs
@@ -34,8 +34,9 @@ namespace SilverlightApp.Views
             var wrapPanel = ParticipantsList.GetItemsHost() as WrapPanel;
             if (wrapPanel == null) return;
 
-            wrapPanel.MaxHeight = ((FrameworkElement)sender).ActualHeight;
-            wrapPanel.MaxWidth = ((FrameworkElement)sender).ActualWidth;
+            wrapPanel.MaxHeight = ((FrameworkElement)sender).ActualHeight - 20;
+            
+            //wrapPanel.MaxWidth = ((FrameworkElement)sender).ActualWidth;
         }
 
         private void RemoveParticipant_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Since it was forced in xaml a maxheight in the WrapPanel, when window size was smaller the vertical scrollbar appear.

it was changed the height to their default values and add a listener that changed dynamically the panel and now the bug is fixed. 
