### PR TITLE
Bloqueado botão de sorteio quando está a decorrer um sorteio. Existia um...

### DIFF
--- a/src/SilverlightApp/Controls/TagCloud.cs
+++ b/src/SilverlightApp/Controls/TagCloud.cs
@@ -19,6 +19,8 @@ namespace SilverlightApp.Controls
 
         public TagItem TopItem;
 
+        public event EventHandler WinnerFound;
+
         public TagCloud()
         {
             Loaded += TagCloud_Loaded;
@@ -87,6 +89,7 @@ namespace SilverlightApp.Controls
                 if (TopItem != null)
                 {
                     TopItem.SetAsWinner();
+                    WinnerFound(null, null);
                 }
             }
         }

--- a/src/SilverlightApp/Controls/TagRandomizer.xaml.cs
+++ b/src/SilverlightApp/Controls/TagRandomizer.xaml.cs
@@ -30,6 +30,7 @@ namespace SilverlightApp.Controls
 
             _timer = new DispatcherTimer();
             _timer.Tick += Timer_Tick;
+            Cloud.WinnerFound += Cloud_WinnerFound;
         }
         #endregion
 
@@ -58,6 +59,8 @@ namespace SilverlightApp.Controls
 
         private void Go_Click(object sender, RoutedEventArgs e)
         {
+            Go.IsEnabled = false;
+
             var selectedTag = Cloud.TopItem;
             if (selectedTag != null)
             {
@@ -66,6 +69,11 @@ namespace SilverlightApp.Controls
 
             Cloud.SetTags(_members.ToArray());
             RandomMembers();
+        }
+
+        private void Cloud_WinnerFound(object sender, EventArgs e)
+        {
+            Go.IsEnabled = true;
         }
         #endregion
     }


### PR DESCRIPTION
... bug que fazia com que os participantes fossem removidos sempre que era carregado o botão a meio do sorteio.
