### PR TITLE
Remove keyword binding

### DIFF
--- a/src/HTML5/index.html
+++ b/src/HTML5/index.html
@@ -67,11 +67,10 @@
                                 </div>
                                 <div class="panel-body">
                                     <p class="text-justify">
-                                        Com a tecla <code>h</code> poderá fazer sair o próximo. Nota que, apenas quando sai um, é que poderá fazer
-                                        sair o seguinte.
+                                            Com o botão <button class="btn btn-success"><span class="glyphicon glyphicon-random"></span></button> poderá sortear o proximo concorrente. 
                                     </p>
                                     <p class="text-justify">
-                                        Existe também um botão <button class="btn btn-success"><span class="glyphicon glyphicon-random"></span></button> no topo das tabs, no lado direito, logo após de dar inicio ao sorteio.
+                                   Nota que, apenas quando sai um, é que poderá fazer  sair o seguinte. Localiza-se  no topo das tabs, no lado direito, logo após de dar inicio ao sorteio.
                                     </p>
                                     <p class="text-justify">Sempre que sai um vencedor, esse botão também aparece no <code>modal</code>.</p>
                                 </div>
@@ -159,7 +158,7 @@
             <a href='javascript:void(0);' data-bind="text:name"></a>
         </div>
 
-        <div class=".col-md-3 .col-md-offset-3" data-bind="visible:version" style="display:none;position:absolute;bottom:5px;left:5px;margin:0;padding:5px 3px;">
+        <div class="col-md-3 col-md-offset-3" data-bind="visible:version" style="display:none;position:absolute;bottom:5px;left:5px;margin:0;padding:5px 3px;">
             <a href="#" style="color: black; text-decoration: initial;" data-bind="attr: {title:version}" style="">π</a>
         </div>
     </div>

--- a/src/HTML5/js/app.js
+++ b/src/HTML5/js/app.js
@@ -188,15 +188,3 @@ function result(e, item) {
         }
     });
 }
-
-$(document).keydown(function (e) {
-    switch (e.which) {
-        // h
-        case 72:
-            RollIt();
-            break;
-        default:
-            return; // exit this handler for other keys
-    }
-    e.preventDefault(); // prevent the default action (scroll / move caret)
-});


### PR DESCRIPTION
On the title, if you try to type something with an `h`, you just can't because of the key binding.

Happened on the October 13th when trying to create a new event "23 Evento NetPonto - Reactor`H`ub".

Had to copy-paste the `h`